### PR TITLE
+ core: Add support for Resource IDs to `toast`

### DIFF
--- a/macroid-core/src/main/scala/macroid/ToastDsl.scala
+++ b/macroid-core/src/main/scala/macroid/ToastDsl.scala
@@ -25,6 +25,16 @@ private[macroid] trait ToastBuilding {
   def toast(text: CharSequence)(implicit ctx: AppContext): Ui[Toast] =
     Ui(Toast.makeText(ctx.get, text, Toast.LENGTH_SHORT))
 
+  /** Create a toast with the specified resource ID */
+  def toast(text: Int)(implicit ctx: AppContext): Ui[Toast] =
+    Ui(Toast.makeText(ctx.get, text, Toast.LENGTH_SHORT))
+
+  /** Create a toast with either the specified text or the specified resource ID */
+  def toast(text: Either[Int, CharSequence])(implicit ctx: AppContext): Ui[Toast] = text match {
+    case Right(t) => Ui(Toast.makeText(ctx.get, t, Toast.LENGTH_SHORT))
+    case Left(t) => Ui(Toast.makeText(ctx.get, t, Toast.LENGTH_SHORT))
+  }
+
   /** Create a toast with the specified view */
   def toast(view: Ui[View])(implicit ctx: AppContext): Ui[Toast] =
     view.map(v ⇒ new Toast(ctx.get) { setView(v); setDuration(Toast.LENGTH_SHORT) })


### PR DESCRIPTION
This brings its API inline with other places that can accept either a
string or a resource ID, such as `text`.