### PR TITLE
+ core: Add an allCaps tweak for `TextView`

### DIFF
--- a/macroid-core/src/main/scala/macroid/contrib/ExtraTweaks.scala
+++ b/macroid-core/src/main/scala/macroid/contrib/ExtraTweaks.scala
@@ -41,6 +41,9 @@ object TextTweaks {
   val medium = size(18)
   val large = size(22)
 
+  def allCaps: Tweak[W] = allCaps(false)
+  def allCaps(value: Boolean) = Tweak[W](_.setAllCaps(value))
+
   private def typefaceStyle(x: W) = Option(x.getTypeface).map(_.getStyle).getOrElse(Typeface.NORMAL)
 }
 

--- a/macroid-core/src/test/scala/macroid/TweakingSpec.scala
+++ b/macroid-core/src/test/scala/macroid/TweakingSpec.scala
@@ -5,6 +5,7 @@ import android.widget.{ LinearLayout, TextView, Button }
 import android.app.Activity
 import LayoutDsl._
 import Tweaks._
+import contrib._
 
 class TweakingSpec extends FlatSpec {
   implicit val ctx = ActivityContext(null: Activity)
@@ -54,6 +55,18 @@ class TweakingSpec extends FlatSpec {
         w[TextView] <~ lp[LinearLayout](0, 0, 1.0f)
       )
       val z = lp[LinearLayout](0, 0, 1.0f)
+    }
+  }
+
+  "TextTweaks.allCaps" should "be invokeable without parenthesis" in {
+    def foo = {
+      w[TextView] <~ TextTweaks.allCaps
+    }
+  }
+
+  it should "allow an optional value" in {
+    def foo = {
+      w[TextView] <~ TextTweaks.allCaps(false)
     }
   }
 }


### PR DESCRIPTION
This is a pretty straightforward addition. It's implemented with
explicit overloading, because a default parameter would require explicit
parenthesis. Presumably 99% of invocations of this will be to enable
all caps, not disable.